### PR TITLE
wait for new configuration if connection fails

### DIFF
--- a/oss_packages/src/modbus_to_mqtt_gateway-1.0/main.c
+++ b/oss_packages/src/modbus_to_mqtt_gateway-1.0/main.c
@@ -106,6 +106,10 @@ int main(void)
     mosq = mosquitto_initialize(CONFIG_FILE_PATH);
     if(mosq == NULL) {
         log_entry(APP_NAME, "Error: Could not initialize mqtt connection");
+        
+        /* wait for new config */
+        while(1);
+        
         return EXIT_FAILURE;
     }
 
@@ -114,6 +118,10 @@ int main(void)
     ctx = modbus_init(CONFIG_FILE_PATH);
     if(ctx == NULL) {
         log_entry(APP_NAME, "Error: Could not initialize modbus connection");
+        
+        /* wait for new config */
+        while(1);
+        
         return EXIT_FAILURE;
     }
 

--- a/oss_packages/src/modbus_to_mqtt_gateway-1.0/main.c
+++ b/oss_packages/src/modbus_to_mqtt_gateway-1.0/main.c
@@ -83,6 +83,11 @@ int main(void)
     if(getStringFromFile_n(CONFIG_FILE_PATH, "mosquitto_topic", topic, BUFFER_SIZE) == -1) {
         log_entry(APP_NAME, "Error reading topic");
         printf("Error reading topic..\n");
+        
+        /* wait for new config */
+        while(1);
+        
+        return EXIT_FAILURE;
     }
 
     pollingInterval = getIntFromFile(CONFIG_FILE_PATH, "modbus_polling_Interval");
@@ -94,6 +99,10 @@ int main(void)
     /* Check values of variables */
     if(check_values(no_register, pollingInterval) == ERROR) {
         log_entry(APP_NAME, "Error: Invalid values");
+        
+        /* wait for new config */
+        while(1);
+        
         return EXIT_FAILURE;
     }
 
@@ -106,10 +115,10 @@ int main(void)
     mosq = mosquitto_initialize(CONFIG_FILE_PATH);
     if(mosq == NULL) {
         log_entry(APP_NAME, "Error: Could not initialize mqtt connection");
-        
+
         /* wait for new config */
         while(1);
-        
+
         return EXIT_FAILURE;
     }
 
@@ -118,10 +127,10 @@ int main(void)
     ctx = modbus_init(CONFIG_FILE_PATH);
     if(ctx == NULL) {
         log_entry(APP_NAME, "Error: Could not initialize modbus connection");
-        
+
         /* wait for new config */
         while(1);
-        
+
         return EXIT_FAILURE;
     }
 

--- a/oss_packages/src/modbus_to_mqtt_gateway-1.0/main.c
+++ b/oss_packages/src/modbus_to_mqtt_gateway-1.0/main.c
@@ -49,11 +49,17 @@ int check_values(int no_register, int pollingInterval)
     return SUCCESS;
 }
 
+/* wait for app_handler to restart the application in case of a new configuration */
+void wait_for_new_config() {
+    while(1) {
+        sleep(100);
+    }
+}
+
 int main(void)
 {
 
 /* ######################### Variables #########################  */
-
 
     /* Variables for modbus */
     modbus_t *ctx;
@@ -85,7 +91,7 @@ int main(void)
         printf("Error reading topic..\n");
         
         /* wait for new config */
-        while(1);
+        wait_for_new_config();
         
         return EXIT_FAILURE;
     }
@@ -101,14 +107,13 @@ int main(void)
         log_entry(APP_NAME, "Error: Invalid values");
         
         /* wait for new config */
-        while(1);
+        wait_for_new_config();
         
         return EXIT_FAILURE;
     }
 
 
 /* ######################### Initialize communication #########################  */
-
 
     /* Initialize Mosquitto */
     printf(SPLIT_LINE);
@@ -117,7 +122,7 @@ int main(void)
         log_entry(APP_NAME, "Error: Could not initialize mqtt connection");
 
         /* wait for new config */
-        while(1);
+        wait_for_new_config();
 
         return EXIT_FAILURE;
     }
@@ -129,7 +134,7 @@ int main(void)
         log_entry(APP_NAME, "Error: Could not initialize modbus connection");
 
         /* wait for new config */
-        while(1);
+        wait_for_new_config();
 
         return EXIT_FAILURE;
     }
@@ -139,7 +144,6 @@ int main(void)
 
 
 /* ######################### Start application #########################  */
-
 
     printf(SPLIT_LINE);
     log_entry(APP_NAME, "Start reading values..");

--- a/rootfs_skeleton/etc/configuration.config.d/configuration_modbus_to_mqtt_gateway.config
+++ b/rootfs_skeleton/etc/configuration.config.d/configuration_modbus_to_mqtt_gateway.config
@@ -3,7 +3,7 @@
 modbus_polling_Interval=10
 
 ##### Modbus #####
-modbus_address=192.168.2.101
+modbus_address=
 modbus_port=502
 modbus_register=1
 modbus_register_type=2
@@ -11,6 +11,6 @@ modbus_desired_bit=0
 modbus_data_type=5
 
 ##### MQTT #####
-mosquitto_address=192.168.2.3
+mosquitto_address=
 mosquitto_port=1884
 mosquitto_topic=/Container


### PR DESCRIPTION
avoid restart of the application in case of connection to mqtt broker or modbus device could not be established successfully. 
instead wait until the user creates a new configuration and then try again.