### PR TITLE
Fixed FILESYSTEM_LIST

### DIFF
--- a/scripts/mk_container.sh
+++ b/scripts/mk_container.sh
@@ -108,7 +108,7 @@ do_strip()
 process_filesystem_list()
 {
     ACTION="${1}"
-    FILESYSTEM_LIST="${SCRIPTSDIR}/rootfs_lists/${2}"
+    FILESYSTEM_LIST="${2}"
     FS_OUTFILE="${3}"
 
     echo "-> Creating archive $FS_OUTFILE containing the root file system"


### PR DESCRIPTION
Changed __FILESYSTEM_LIST="${SCRIPTSDIR}/rootfs_lists/${2}"__ to __FILESYSTEM_LIST="${2}"__ because entering the command
`./scripts/mk_container.sh -l scripts/rootfs_lists/default.txt -n "My_first_container" -v 1.0`
will result in
`Creating archive /home/user/M3_Container/working/update/rootfs.tar containing the root file system ERROR: the given list file "./scripts/rootfs_lists/scripts/rootfs_lists/default.txt" does not exist`